### PR TITLE
Remove Wavefront server and api tokens

### DIFF
--- a/distributed-tracing/opencensus-dropwizard-app/delivery/wf-reporting-config.yaml
+++ b/distributed-tracing/opencensus-dropwizard-app/delivery/wf-reporting-config.yaml
@@ -1,6 +1,6 @@
 # Reporting through direct ingestion
 reportingMechanism: "direct"
-server: "https://virunga.wavefront.com"
-token: "4056c005-f557-4ca1-b699-83d5f86e1d93"
+server: "https://<YOUR WAVEFRONT SERVER>.wavefront.com"
+token: "<YOUR WAVEFRONT API TOKEN>"
 source: "wavefront-tracing-example"
 reportTraces: true

--- a/distributed-tracing/opencensus-dropwizard-app/shopping/wf-reporting-config.yaml
+++ b/distributed-tracing/opencensus-dropwizard-app/shopping/wf-reporting-config.yaml
@@ -1,6 +1,6 @@
 # Reporting through direct ingestion
 reportingMechanism: "direct"
-server: "https://virunga.wavefront.com"
-token: "4056c005-f557-4ca1-b699-83d5f86e1d93"
+server: "https://<YOUR WAVEFRONT SERVER>.wavefront.com"
+token: "<YOUR WAVEFRONT API TOKEN>"
 source: "wavefront-tracing-example"
 reportTraces: true

--- a/distributed-tracing/opencensus-dropwizard-app/styling/wf-reporting-config.yaml
+++ b/distributed-tracing/opencensus-dropwizard-app/styling/wf-reporting-config.yaml
@@ -1,6 +1,6 @@
 # Reporting through direct ingestion
 reportingMechanism: "direct"
-server: "https://virunga.wavefront.com"
-token: "4056c005-f557-4ca1-b699-83d5f86e1d93"
+server: "https://<YOUR WAVEFRONT SERVER>.wavefront.com"
+token: "<YOUR WAVEFRONT API TOKEN>"
 source: "wavefront-tracing-example"
 reportTraces: true


### PR DESCRIPTION
Wavefront server and api tokens were replaced with placeholders to match other sample applications and configuration. These values should not be hardcoded.